### PR TITLE
fix: base issue and MR title truncation on list width (#22)

### DIFF
--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -542,10 +542,9 @@ func (m DashboardModel) renderMain(width int, height int) string {
 		lines = append(lines, "  No items")
 	} else if m.view != PrimaryView {
 		contentWidth := max(10, width-8)
-		rowWidth := max(1, contentWidth-2)
+		rowWidth := listRowWidth(contentWidth)
 		rowsPerItem := 1
 		if m.view == IssuesView {
-			rowWidth = minInt(rowWidth, 52)
 			rowsPerItem = 2
 		} else if m.view == MergeRequestsView {
 			rowsPerItem = 2
@@ -1605,6 +1604,10 @@ func fitLine(input string, width int) string {
 		return string(runes[:width])
 	}
 	return string(runes[:width-1]) + "…"
+}
+
+func listRowWidth(contentWidth int) int {
+	return max(1, contentWidth-2)
 }
 
 func visibleRange(total int, selected int, capacity int) (int, int) {

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -585,3 +585,29 @@ func TestDashboardMergeRequestDetailOpensAndCloses(t *testing.T) {
 		t.Fatal("expected merge request detail view to close")
 	}
 }
+
+func TestListRowWidthTracksAvailableWidth(t *testing.T) {
+	t.Parallel()
+
+	if got := listRowWidth(80); got != 78 {
+		t.Fatalf("listRowWidth(80) = %d want %d", got, 78)
+	}
+	if got := listRowWidth(3); got != 1 {
+		t.Fatalf("listRowWidth(3) = %d want %d", got, 1)
+	}
+}
+
+func TestListTitleTruncationBasedOnRowWidth(t *testing.T) {
+	t.Parallel()
+
+	long := "Issue and merge request titles should only truncate when width is narrow"
+	wide := listRowWidth(120)
+	narrow := listRowWidth(24)
+
+	if got := fitLine(long, wide); got != long {
+		t.Fatalf("wide fitLine truncated title: %q", got)
+	}
+	if got := fitLine(long, narrow); got == long {
+		t.Fatalf("narrow fitLine did not truncate title: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- remove the hard-coded 52-character cap from issue list rows and compute list row width from available panel content width
- share the same row-width logic across issue and merge request list rendering, so both screens truncate titles only when space is actually constrained
- add tests for shared row-width behavior and truncation rules on wide vs narrow widths

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard list display now dynamically utilizes available terminal width without artificial constraints, improving layout consistency across different screen sizes.

* **Tests**
  * Added test coverage for width calculation and text truncation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->