### PR TITLE
feat: render markdown tables in TUI (#38)

### DIFF
--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
 )
 
 type loadedMsg struct {
@@ -1639,14 +1640,13 @@ func fitLine(input string, width int) string {
 	if width <= 0 {
 		return ""
 	}
-	runes := []rune(input)
-	if len(runes) <= width {
+	if xansi.StringWidth(input) <= width {
 		return input
 	}
 	if width <= 1 {
-		return string(runes[:width])
+		return xansi.Truncate(input, width, "")
 	}
-	return string(runes[:width-1]) + "…"
+	return xansi.Truncate(input, width, "…")
 }
 
 func listRowWidth(contentWidth int) int {

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -690,3 +690,20 @@ func TestListTitleTruncationBasedOnRowWidth(t *testing.T) {
 		t.Fatalf("narrow fitLine did not truncate title: %q", got)
 	}
 }
+
+func TestFitLinePreservesANSISequences(t *testing.T) {
+	t.Parallel()
+
+	styled := "\x1b[31mabcdef\x1b[0m"
+	got := fitLine(styled, 4)
+
+	if stripANSI(got) != "abc…" {
+		t.Fatalf("expected visible text to truncate to abc…, got %q", stripANSI(got))
+	}
+	if len([]rune(stripANSI(got))) != 4 {
+		t.Fatalf("expected rendered visible width 4, got %d", len([]rune(stripANSI(got))))
+	}
+	if !strings.Contains(got, "\x1b[") {
+		t.Fatalf("expected ANSI sequences to be preserved, got %q", got)
+	}
+}

--- a/internal/tui/markdown_renderer.go
+++ b/internal/tui/markdown_renderer.go
@@ -13,6 +13,8 @@ import (
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	extast "github.com/yuin/goldmark/extension/ast"
 	"github.com/yuin/goldmark/text"
 )
 
@@ -69,7 +71,9 @@ func renderMarkdownStructured(input string, width int) []string {
 		return nil
 	}
 	source := []byte(input)
-	md := goldmark.New()
+	md := goldmark.New(
+		goldmark.WithExtensions(extension.Table),
+	)
 	doc := md.Parser().Parse(text.NewReader(source))
 	lines := renderMarkdownBlocks(doc, source, max(8, width), "")
 	if len(lines) == 0 {
@@ -95,6 +99,9 @@ func renderMarkdownBlocks(parent ast.Node, source []byte, width int, prefix stri
 			out = append(out, "")
 		case *ast.List:
 			out = append(out, renderMarkdownList(typed, source, width, prefix)...)
+			out = append(out, "")
+		case *extast.Table:
+			out = append(out, renderMarkdownTable(typed, source, width, prefix)...)
 			out = append(out, "")
 		case *ast.FencedCodeBlock:
 			lang := strings.TrimSpace(string(typed.Language(source)))
@@ -226,6 +233,201 @@ func extractCodeBlockLines(lines *text.Segments, source []byte) []string {
 		out = append(out, strings.TrimRight(string(segment.Value(source)), "\r\n"))
 	}
 	return out
+}
+
+func renderMarkdownTable(table *extast.Table, source []byte, width int, prefix string) []string {
+	rows := make([][]string, 0, 4)
+	for child := table.FirstChild(); child != nil; child = child.NextSibling() {
+		switch typed := child.(type) {
+		case *extast.TableHeader:
+			rows = append(rows, renderMarkdownTableRow(typed, source))
+		case *extast.TableRow:
+			rows = append(rows, renderMarkdownTableRow(typed, source))
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	columnCount := maxTableColumns(rows, len(table.Alignments))
+	if columnCount <= 0 {
+		return nil
+	}
+	normalized := normalizeTableRows(rows, columnCount)
+	columnWidths := fitTableColumnWidths(normalized, width-lipgloss.Width(prefix), columnCount)
+	if len(columnWidths) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(normalized)+1)
+	out = append(out, renderTableLine(normalized[0], columnWidths, table.Alignments, prefix))
+	out = append(out, renderTableSeparator(columnWidths, table.Alignments, prefix))
+	for _, row := range normalized[1:] {
+		out = append(out, renderTableLine(row, columnWidths, table.Alignments, prefix))
+	}
+	return out
+}
+
+func renderMarkdownTableRow(row ast.Node, source []byte) []string {
+	columns := make([]string, 0, 4)
+	for child := row.FirstChild(); child != nil; child = child.NextSibling() {
+		cell, ok := child.(*extast.TableCell)
+		if !ok {
+			continue
+		}
+		value := strings.ReplaceAll(renderInlineChildren(cell, source), "\n", " ")
+		columns = append(columns, strings.TrimSpace(value))
+	}
+	return columns
+}
+
+func maxTableColumns(rows [][]string, alignments int) int {
+	maxColumns := alignments
+	for _, row := range rows {
+		if len(row) > maxColumns {
+			maxColumns = len(row)
+		}
+	}
+	return maxColumns
+}
+
+func normalizeTableRows(rows [][]string, columns int) [][]string {
+	normalized := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		current := make([]string, columns)
+		for i := 0; i < columns; i++ {
+			if i < len(row) {
+				current[i] = row[i]
+				continue
+			}
+			current[i] = ""
+		}
+		normalized = append(normalized, current)
+	}
+	return normalized
+}
+
+func fitTableColumnWidths(rows [][]string, totalWidth int, columns int) []int {
+	if columns <= 0 {
+		return nil
+	}
+	available := totalWidth - (3*columns + 1)
+	if available <= 0 {
+		available = columns
+	}
+
+	widths := make([]int, columns)
+	for col := 0; col < columns; col++ {
+		maxWidth := 1
+		for _, row := range rows {
+			cellWidth := lipgloss.Width(stripANSI(row[col]))
+			if cellWidth > maxWidth {
+				maxWidth = cellWidth
+			}
+		}
+		widths[col] = maxWidth
+	}
+
+	for sumInt(widths) > available {
+		index := widestShrinkableColumn(widths)
+		if index < 0 {
+			break
+		}
+		widths[index]--
+	}
+	return widths
+}
+
+func widestShrinkableColumn(widths []int) int {
+	index := -1
+	maxWidth := 1
+	for i, width := range widths {
+		if width <= 1 {
+			continue
+		}
+		if index == -1 || width > maxWidth {
+			index = i
+			maxWidth = width
+		}
+	}
+	return index
+}
+
+func sumInt(values []int) int {
+	total := 0
+	for _, value := range values {
+		total += value
+	}
+	return total
+}
+
+func renderTableLine(row []string, widths []int, alignments []extast.Alignment, prefix string) string {
+	parts := make([]string, 0, len(widths))
+	for i := 0; i < len(widths); i++ {
+		alignment := extast.AlignNone
+		if i < len(alignments) {
+			alignment = alignments[i]
+		}
+		cell := ""
+		if i < len(row) {
+			cell = row[i]
+		}
+		parts = append(parts, alignTableCell(cell, widths[i], alignment))
+	}
+	return prefix + "| " + strings.Join(parts, " | ") + " |"
+}
+
+func renderTableSeparator(widths []int, alignments []extast.Alignment, prefix string) string {
+	parts := make([]string, 0, len(widths))
+	for i, width := range widths {
+		alignment := extast.AlignNone
+		if i < len(alignments) {
+			alignment = alignments[i]
+		}
+		parts = append(parts, tableSeparatorSegment(width, alignment))
+	}
+	return prefix + "| " + strings.Join(parts, " | ") + " |"
+}
+
+func alignTableCell(cell string, width int, alignment extast.Alignment) string {
+	trimmed := strings.TrimSpace(cell)
+	truncated := fitLine(trimmed, width)
+	padding := width - lipgloss.Width(stripANSI(truncated))
+	if padding <= 0 {
+		return truncated
+	}
+	leftPad := 0
+	rightPad := 0
+	switch alignment {
+	case extast.AlignRight:
+		leftPad = padding
+	case extast.AlignCenter:
+		leftPad = padding / 2
+		rightPad = padding - leftPad
+	default:
+		rightPad = padding
+	}
+	return strings.Repeat(" ", leftPad) + truncated + strings.Repeat(" ", rightPad)
+}
+
+func tableSeparatorSegment(width int, alignment extast.Alignment) string {
+	if width <= 1 {
+		if alignment == extast.AlignCenter || alignment == extast.AlignLeft || alignment == extast.AlignRight {
+			return ":"
+		}
+		return "-"
+	}
+	segment := []rune(strings.Repeat("-", width))
+	switch alignment {
+	case extast.AlignLeft:
+		segment[0] = ':'
+	case extast.AlignRight:
+		segment[len(segment)-1] = ':'
+	case extast.AlignCenter:
+		segment[0] = ':'
+		segment[len(segment)-1] = ':'
+	}
+	return string(segment)
 }
 
 func renderMarkdownList(list *ast.List, source []byte, width int, prefix string) []string {

--- a/internal/tui/markdown_renderer_test.go
+++ b/internal/tui/markdown_renderer_test.go
@@ -158,6 +158,9 @@ func TestRenderMarkdownStructuredTableNarrowWidth(t *testing.T) {
 	if len(lines) == 0 {
 		t.Fatal("expected structured markdown output")
 	}
+	if !containsLineWithPrefix(lines, "|") {
+		t.Fatalf("expected table output with pipe-delimited lines, got %#v", lines)
+	}
 	for _, line := range lines {
 		clean := stripANSI(line)
 		if strings.TrimSpace(clean) == "" {
@@ -166,6 +169,23 @@ func TestRenderMarkdownStructuredTableNarrowWidth(t *testing.T) {
 		if len([]rune(clean)) > width {
 			t.Fatalf("expected rendered table line width <= %d, got %d for line %q", width, len([]rune(clean)), clean)
 		}
+	}
+}
+
+func TestRenderMarkdownStructuredTableCodeCellKeepsContentWhenSpaceAllows(t *testing.T) {
+	input := strings.Join([]string{
+		"| Package | Type | Update | Change |",
+		"|---|---|---|---|",
+		"| gcc |  | patch | `15.2.0-r8` → `15.2.0-r9` |",
+	}, "\n")
+
+	lines := renderMarkdownStructured(input, 120)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, "15.2...") {
+		t.Fatalf("expected code cell not to be aggressively truncated, got %#v", lines)
+	}
+	if !strings.Contains(joined, "`15.2.0-r8` → `15.2.0-r9`") {
+		t.Fatalf("expected full code change content in table cell, got %#v", lines)
 	}
 }
 

--- a/internal/tui/markdown_renderer_test.go
+++ b/internal/tui/markdown_renderer_test.go
@@ -123,6 +123,52 @@ func TestRenderMarkdownStructuredNestedLists(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownStructuredTable(t *testing.T) {
+	input := strings.Join([]string{
+		"| Name | Status |",
+		"| :--- | ---: |",
+		"| parser | done |",
+		"| tests | pending |",
+	}, "\n")
+
+	lines := renderMarkdownStructured(input, 60)
+	if len(lines) == 0 {
+		t.Fatal("expected structured markdown output")
+	}
+	if !containsLineWithPrefix(lines, "| Name") {
+		t.Fatalf("expected table header row, got %#v", lines)
+	}
+	if !containsLineWithPrefix(lines, "| :") {
+		t.Fatalf("expected table separator row with alignment markers, got %#v", lines)
+	}
+	if !containsLineWithPrefix(lines, "| parser") {
+		t.Fatalf("expected table body row, got %#v", lines)
+	}
+}
+
+func TestRenderMarkdownStructuredTableNarrowWidth(t *testing.T) {
+	input := strings.Join([]string{
+		"| Column One | Column Two | Column Three |",
+		"| :--- | ---: | :---: |",
+		"| alpha value | beta value | gamma value |",
+	}, "\n")
+
+	width := 22
+	lines := renderMarkdownStructured(input, width)
+	if len(lines) == 0 {
+		t.Fatal("expected structured markdown output")
+	}
+	for _, line := range lines {
+		clean := stripANSI(line)
+		if strings.TrimSpace(clean) == "" {
+			continue
+		}
+		if len([]rune(clean)) > width {
+			t.Fatalf("expected rendered table line width <= %d, got %d for line %q", width, len([]rune(clean)), clean)
+		}
+	}
+}
+
 func containsLineWithPrefix(lines []string, prefix string) bool {
 	for _, line := range lines {
 		if strings.HasPrefix(strings.TrimSpace(stripANSI(line)), prefix) {


### PR DESCRIPTION
## Summary
- enable GFM table parsing in the structured markdown renderer used by issue and merge request detail panes
- add a terminal-friendly table renderer with width-aware column sizing, alignment handling, and truncation to prevent viewport overflow
- add tests covering standard table rendering and narrow-width behavior

## Testing
- just test

## Issue
- Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown tables are now fully rendered in the TUI with automatic column width fitting, cell alignment (left/center/right), separators, and graceful truncation to fit display widths.

* **Improvements**
  * Truncation and width calculations are now ANSI-aware, preserving escape sequences and correctly measuring visible character width.

* **Tests**
  * Added tests validating table rendering across widths and that truncation preserves ANSI sequences and visible-width constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->