### PR TITLE
feat: metadata search + autocomplete for issues and merge requests (#40)

### DIFF
--- a/internal/app/mock_provider.go
+++ b/internal/app/mock_provider.go
@@ -213,8 +213,8 @@ func (p *MockProvider) LoadIssueDetailData(_ context.Context, issueIID int64) (t
 
 func (p *MockProvider) LoadSearchMetadata(context.Context, tui.ViewMode) (tui.SearchMetadata, error) {
 	return tui.SearchMetadata{
-		Authors:    []string{"mock-author", "mock-reviewer"},
-		Assignees:  []string{"mock-assignee", "mock-author"},
+		Authors:    []tui.SearchUser{{Name: "Mock Author", Username: "mock-author"}, {Name: "Mock Reviewer", Username: "mock-reviewer"}},
+		Assignees:  []tui.SearchUser{{Name: "Mock Assignee", Username: "mock-assignee"}, {Name: "Mock Author", Username: "mock-author"}},
 		Labels:     []string{"mock", "ui", "backend"},
 		Milestones: []string{"Iteration 1", "Iteration 2"},
 	}, nil

--- a/internal/app/mock_provider.go
+++ b/internal/app/mock_provider.go
@@ -211,6 +211,15 @@ func (p *MockProvider) LoadIssueDetailData(_ context.Context, issueIID int64) (t
 	}, nil
 }
 
+func (p *MockProvider) LoadSearchMetadata(context.Context, tui.ViewMode) (tui.SearchMetadata, error) {
+	return tui.SearchMetadata{
+		Authors:    []string{"mock-author", "mock-reviewer"},
+		Assignees:  []string{"mock-assignee", "mock-author"},
+		Labels:     []string{"mock", "ui", "backend"},
+		Milestones: []string{"Iteration 1", "Iteration 2"},
+	}, nil
+}
+
 func containsAll(values []string, required []string) bool {
 	set := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/internal/app/provider_search_test.go
+++ b/internal/app/provider_search_test.go
@@ -141,7 +141,7 @@ func TestProviderResolvesAuthorNameToUsername(t *testing.T) {
 	client := &captureClient{members: []*gl.ProjectMember{{Name: "Alice Doe", Username: "d2db03f2-aaaa-bbbb-cccc-f59ec9974ed2"}}}
 	provider := NewProvider(client, "group/project")
 
-	_, err := provider.LoadIssues(context.Background(), tui.IssueQuery{State: tui.IssueStateOpened, Search: "author:\"Alice Doe\""})
+	_, err := provider.LoadIssues(context.Background(), tui.IssueQuery{State: tui.IssueStateOpened, Search: "author:Alice Doe label:backend"})
 	if err != nil {
 		t.Fatalf("LoadIssues() error = %v", err)
 	}

--- a/internal/app/provider_search_test.go
+++ b/internal/app/provider_search_test.go
@@ -87,10 +87,10 @@ func TestProviderParsesIssueMetadataSearch(t *testing.T) {
 func TestProviderParsesMergeRequestMetadataSearch(t *testing.T) {
 	t.Parallel()
 
-	client := &captureClient{}
+	client := &captureClient{members: []*gl.ProjectMember{{ID: 101, Name: "Bob", Username: "bob"}}}
 	provider := NewProvider(client, "group/project")
 
-	_, err := provider.LoadMergeRequests(context.Background(), tui.MergeRequestQuery{State: tui.MergeRequestStateOpened, Search: "cleanup author:alice label:frontend"})
+	_, err := provider.LoadMergeRequests(context.Background(), tui.MergeRequestQuery{State: tui.MergeRequestStateOpened, Search: "cleanup author:alice assignee:Bob label:frontend"})
 	if err != nil {
 		t.Fatalf("LoadMergeRequests() error = %v", err)
 	}
@@ -103,6 +103,9 @@ func TestProviderParsesMergeRequestMetadataSearch(t *testing.T) {
 	}
 	if len(client.mrOpts.Labels) != 1 || client.mrOpts.Labels[0] != "frontend" {
 		t.Fatalf("Labels = %#v want %#v", client.mrOpts.Labels, []string{"frontend"})
+	}
+	if client.mrOpts.AssigneeID != 101 {
+		t.Fatalf("AssigneeID = %d want %d", client.mrOpts.AssigneeID, 101)
 	}
 }
 

--- a/internal/app/provider_search_test.go
+++ b/internal/app/provider_search_test.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/davzucky/lazygitlab/internal/gitlab"
+	"github.com/davzucky/lazygitlab/internal/tui"
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+type captureClient struct {
+	issueOpts gitlab.IssueListOptions
+	mrOpts    gitlab.MergeRequestListOptions
+}
+
+func (c *captureClient) GetCurrentUser(context.Context) (*gl.User, error) {
+	return nil, nil
+}
+
+func (c *captureClient) GetProject(context.Context, string) (*gl.Project, error) {
+	return nil, nil
+}
+
+func (c *captureClient) ListProjects(context.Context, string) ([]*gl.Project, error) {
+	return nil, nil
+}
+
+func (c *captureClient) ListIssues(_ context.Context, _ string, opts gitlab.IssueListOptions) ([]*gl.Issue, bool, error) {
+	c.issueOpts = opts
+	return nil, false, nil
+}
+
+func (c *captureClient) ListIssueNotes(context.Context, string, int64) ([]*gl.Note, error) {
+	return nil, nil
+}
+
+func (c *captureClient) ListIssueStateEvents(context.Context, string, int64) ([]*gl.StateEvent, error) {
+	return nil, nil
+}
+
+func (c *captureClient) ListMergeRequests(_ context.Context, _ string, opts gitlab.MergeRequestListOptions) ([]*gl.BasicMergeRequest, bool, error) {
+	c.mrOpts = opts
+	return nil, false, nil
+}
+
+func TestProviderParsesIssueMetadataSearch(t *testing.T) {
+	t.Parallel()
+
+	client := &captureClient{}
+	provider := NewProvider(client, "group/project")
+
+	_, err := provider.LoadIssues(context.Background(), tui.IssueQuery{State: tui.IssueStateOpened, Search: "login author:alice label:backend milestone:v1"})
+	if err != nil {
+		t.Fatalf("LoadIssues() error = %v", err)
+	}
+
+	if client.issueOpts.Search != "login" {
+		t.Fatalf("Search = %q want %q", client.issueOpts.Search, "login")
+	}
+	if client.issueOpts.AuthorUsername != "alice" {
+		t.Fatalf("AuthorUsername = %q want %q", client.issueOpts.AuthorUsername, "alice")
+	}
+	if len(client.issueOpts.Labels) != 1 || client.issueOpts.Labels[0] != "backend" {
+		t.Fatalf("Labels = %#v want %#v", client.issueOpts.Labels, []string{"backend"})
+	}
+	if client.issueOpts.Milestone != "v1" {
+		t.Fatalf("Milestone = %q want %q", client.issueOpts.Milestone, "v1")
+	}
+}
+
+func TestProviderParsesMergeRequestMetadataSearch(t *testing.T) {
+	t.Parallel()
+
+	client := &captureClient{}
+	provider := NewProvider(client, "group/project")
+
+	_, err := provider.LoadMergeRequests(context.Background(), tui.MergeRequestQuery{State: tui.MergeRequestStateOpened, Search: "cleanup author:alice label:frontend"})
+	if err != nil {
+		t.Fatalf("LoadMergeRequests() error = %v", err)
+	}
+
+	if client.mrOpts.Search != "cleanup" {
+		t.Fatalf("Search = %q want %q", client.mrOpts.Search, "cleanup")
+	}
+	if client.mrOpts.AuthorUsername != "alice" {
+		t.Fatalf("AuthorUsername = %q want %q", client.mrOpts.AuthorUsername, "alice")
+	}
+	if len(client.mrOpts.Labels) != 1 || client.mrOpts.Labels[0] != "frontend" {
+		t.Fatalf("Labels = %#v want %#v", client.mrOpts.Labels, []string{"frontend"})
+	}
+}

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -27,16 +27,25 @@ type Client interface {
 }
 
 type IssueListOptions struct {
-	State   string
-	Search  string
-	Page    int64
-	PerPage int
+	State            string
+	Search           string
+	AuthorUsername   string
+	AssigneeUsername string
+	Labels           []string
+	Milestone        string
+	Page             int64
+	PerPage          int
 }
 
 type MergeRequestListOptions struct {
-	State   string
-	Page    int64
-	PerPage int
+	State            string
+	Search           string
+	AuthorUsername   string
+	AssigneeUsername string
+	Labels           []string
+	Milestone        string
+	Page             int64
+	PerPage          int
 }
 
 type client struct {
@@ -147,6 +156,16 @@ func (c *client) ListIssues(ctx context.Context, projectPath string, opts IssueL
 	if opts.Search != "" {
 		apiOpts.Search = gl.Ptr(opts.Search)
 	}
+	if opts.AuthorUsername != "" {
+		apiOpts.AuthorUsername = gl.Ptr(opts.AuthorUsername)
+	}
+	if len(opts.Labels) > 0 {
+		labels := gl.LabelOptions(opts.Labels)
+		apiOpts.Labels = &labels
+	}
+	if opts.Milestone != "" {
+		apiOpts.Milestone = gl.Ptr(opts.Milestone)
+	}
 
 	var issues []*gl.Issue
 	var resp *gl.Response
@@ -238,6 +257,19 @@ func (c *client) ListMergeRequests(ctx context.Context, projectPath string, opts
 	}
 	if opts.State != "" {
 		apiOpts.State = gl.Ptr(opts.State)
+	}
+	if opts.Search != "" {
+		apiOpts.Search = gl.Ptr(opts.Search)
+	}
+	if opts.AuthorUsername != "" {
+		apiOpts.AuthorUsername = gl.Ptr(opts.AuthorUsername)
+	}
+	if len(opts.Labels) > 0 {
+		labels := gl.LabelOptions(opts.Labels)
+		apiOpts.Labels = &labels
+	}
+	if opts.Milestone != "" {
+		apiOpts.Milestone = gl.Ptr(opts.Milestone)
 	}
 
 	var mrs []*gl.BasicMergeRequest

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -42,14 +42,14 @@ type IssueListOptions struct {
 }
 
 type MergeRequestListOptions struct {
-	State            string
-	Search           string
-	AuthorUsername   string
-	AssigneeUsername string
-	Labels           []string
-	Milestone        string
-	Page             int64
-	PerPage          int
+	State          string
+	Search         string
+	AuthorUsername string
+	AssigneeID     int64
+	Labels         []string
+	Milestone      string
+	Page           int64
+	PerPage        int
 }
 
 type client struct {
@@ -258,6 +258,9 @@ func (c *client) ListIssues(ctx context.Context, projectPath string, opts IssueL
 	if opts.AuthorUsername != "" {
 		apiOpts.AuthorUsername = gl.Ptr(opts.AuthorUsername)
 	}
+	if opts.AssigneeUsername != "" {
+		apiOpts.AssigneeUsername = gl.Ptr(opts.AssigneeUsername)
+	}
 	if len(opts.Labels) > 0 {
 		labels := gl.LabelOptions(opts.Labels)
 		apiOpts.Labels = &labels
@@ -362,6 +365,9 @@ func (c *client) ListMergeRequests(ctx context.Context, projectPath string, opts
 	}
 	if opts.AuthorUsername != "" {
 		apiOpts.AuthorUsername = gl.Ptr(opts.AuthorUsername)
+	}
+	if opts.AssigneeID > 0 {
+		apiOpts.AssigneeID = gl.AssigneeID(opts.AssigneeID)
 	}
 	if len(opts.Labels) > 0 {
 		labels := gl.LabelOptions(opts.Labels)

--- a/internal/gitlab/search_query.go
+++ b/internal/gitlab/search_query.go
@@ -1,0 +1,110 @@
+package gitlab
+
+import "strings"
+
+type SearchQuery struct {
+	Text      string
+	Author    string
+	Assignee  string
+	Labels    []string
+	Milestone string
+}
+
+func ParseSearchQuery(raw string) SearchQuery {
+	tokens := splitSearchTokens(raw)
+	query := SearchQuery{}
+	textTerms := make([]string, 0, len(tokens))
+
+	for _, token := range tokens {
+		trimmed := strings.TrimSpace(token)
+		if trimmed == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(trimmed, ":")
+		if !ok {
+			textTerms = append(textTerms, trimmed)
+			continue
+		}
+
+		k := strings.ToLower(strings.TrimSpace(key))
+		v := strings.TrimSpace(value)
+		if v == "" {
+			textTerms = append(textTerms, trimmed)
+			continue
+		}
+
+		switch k {
+		case "author":
+			query.Author = v
+		case "assignee":
+			query.Assignee = v
+		case "label":
+			query.Labels = append(query.Labels, v)
+		case "milestone":
+			query.Milestone = v
+		default:
+			textTerms = append(textTerms, trimmed)
+		}
+	}
+
+	query.Text = strings.TrimSpace(strings.Join(textTerms, " "))
+	query.Labels = uniqueNonEmpty(query.Labels)
+	return query
+}
+
+func splitSearchTokens(raw string) []string {
+	input := strings.TrimSpace(raw)
+	if input == "" {
+		return nil
+	}
+
+	runes := []rune(input)
+	tokens := make([]string, 0, 8)
+	var current strings.Builder
+	inQuote := false
+
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, current.String())
+		current.Reset()
+	}
+
+	for _, r := range runes {
+		switch {
+		case r == '"':
+			inQuote = !inQuote
+		case !inQuote && (r == ' ' || r == '\t' || r == '\n'):
+			flush()
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	flush()
+	return tokens
+}
+
+func uniqueNonEmpty(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		unique = append(unique, trimmed)
+	}
+	if len(unique) == 0 {
+		return nil
+	}
+	return unique
+}

--- a/internal/gitlab/search_query_test.go
+++ b/internal/gitlab/search_query_test.go
@@ -40,6 +40,19 @@ func TestParseSearchQueryQuotedMilestoneAndText(t *testing.T) {
 	}
 }
 
+func TestParseSearchQueryUnquotedMultiWordQualifier(t *testing.T) {
+	t.Parallel()
+
+	query := ParseSearchQuery("author:Alice Doe label:backend")
+
+	if query.Author != "Alice Doe" {
+		t.Fatalf("author = %q want %q", query.Author, "Alice Doe")
+	}
+	if !reflect.DeepEqual(query.Labels, []string{"backend"}) {
+		t.Fatalf("labels = %#v want %#v", query.Labels, []string{"backend"})
+	}
+}
+
 func TestParseSearchQueryUnknownQualifierFallsBackToText(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gitlab/search_query_test.go
+++ b/internal/gitlab/search_query_test.go
@@ -1,0 +1,64 @@
+package gitlab
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSearchQueryMetadataAndText(t *testing.T) {
+	t.Parallel()
+
+	query := ParseSearchQuery("bugfix author:alice assignee:bob label:backend label:api milestone:v1.2")
+
+	if query.Text != "bugfix" {
+		t.Fatalf("text = %q want %q", query.Text, "bugfix")
+	}
+	if query.Author != "alice" {
+		t.Fatalf("author = %q want %q", query.Author, "alice")
+	}
+	if query.Assignee != "bob" {
+		t.Fatalf("assignee = %q want %q", query.Assignee, "bob")
+	}
+	if query.Milestone != "v1.2" {
+		t.Fatalf("milestone = %q want %q", query.Milestone, "v1.2")
+	}
+	if !reflect.DeepEqual(query.Labels, []string{"backend", "api"}) {
+		t.Fatalf("labels = %#v want %#v", query.Labels, []string{"backend", "api"})
+	}
+}
+
+func TestParseSearchQueryQuotedMilestoneAndText(t *testing.T) {
+	t.Parallel()
+
+	query := ParseSearchQuery("author:alice milestone:\"Sprint 12\" login failure")
+
+	if query.Milestone != "Sprint 12" {
+		t.Fatalf("milestone = %q want %q", query.Milestone, "Sprint 12")
+	}
+	if query.Text != "login failure" {
+		t.Fatalf("text = %q want %q", query.Text, "login failure")
+	}
+}
+
+func TestParseSearchQueryUnknownQualifierFallsBackToText(t *testing.T) {
+	t.Parallel()
+
+	query := ParseSearchQuery("scope:all label:frontend")
+
+	if query.Text != "scope:all" {
+		t.Fatalf("text = %q want %q", query.Text, "scope:all")
+	}
+	if !reflect.DeepEqual(query.Labels, []string{"frontend"}) {
+		t.Fatalf("labels = %#v want %#v", query.Labels, []string{"frontend"})
+	}
+}
+
+func TestParseSearchQueryDeduplicatesLabels(t *testing.T) {
+	t.Parallel()
+
+	query := ParseSearchQuery("label:backend label:backend label:api")
+
+	if !reflect.DeepEqual(query.Labels, []string{"backend", "api"}) {
+		t.Fatalf("labels = %#v want %#v", query.Labels, []string{"backend", "api"})
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -782,8 +782,17 @@ func (m DashboardModel) renderListLines(contentWidth int, bodyRows int) []string
 			prefix = "› "
 			rowStyle = m.styles.selectedRow
 		}
-		line := prefix + fitLine(item.Title, rowWidth)
-		lines = append(lines, rowStyle.Render(line))
+		if m.view == IssuesView && item.Issue != nil && item.Issue.IID > 0 {
+			issueID := fmt.Sprintf("#%d", item.Issue.IID)
+			idWidth := lipgloss.Width(issueID)
+			titleWidth := max(1, rowWidth-idWidth-1)
+			title := fitLine(item.Title, titleWidth)
+			line := prefix + m.styles.issueID.Render(issueID) + " " + rowStyle.Render(title)
+			lines = append(lines, line)
+		} else {
+			line := prefix + fitLine(item.Title, rowWidth)
+			lines = append(lines, rowStyle.Render(line))
+		}
 		if m.view == IssuesView {
 			meta := "  " + fitLine(issueListMeta(item), rowWidth)
 			lines = append(lines, m.styles.dim.Render(meta))

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1735,13 +1735,6 @@ func qualifierSuggestion(key string, value string) string {
 	if trimmed == "" {
 		return ""
 	}
-	if strings.ContainsAny(trimmed, " \t") {
-		replaced := strings.ReplaceAll(trimmed, "\"", "")
-		if replaced == "" {
-			return ""
-		}
-		return fmt.Sprintf("%s:\"%s\"", key, replaced)
-	}
 	return key + ":" + trimmed
 }
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -615,6 +615,9 @@ func (m DashboardModel) renderMainSplitLines(contentWidth int, bodyRows int) []s
 	if bodyRows <= 0 {
 		return nil
 	}
+	if !m.shouldShowPreview(contentWidth) {
+		return m.renderMainSinglePaneLines(contentWidth, bodyRows)
+	}
 
 	listWidth := max(32, min(contentWidth-26, int(float64(contentWidth)*0.66)))
 	previewWidth := max(24, contentWidth-listWidth-3)
@@ -637,6 +640,29 @@ func (m DashboardModel) renderMainSplitLines(contentWidth int, bodyRows int) []s
 		out = append(out, left+" | "+right)
 	}
 	return out
+}
+
+func (m DashboardModel) shouldShowPreview(contentWidth int) bool {
+	const minPreviewLayoutWidth = 96
+	return contentWidth >= minPreviewLayoutWidth
+}
+
+func (m DashboardModel) renderMainSinglePaneLines(contentWidth int, bodyRows int) []string {
+	if bodyRows <= 0 {
+		return nil
+	}
+	if m.loading {
+		return fitHeight([]string{"  " + m.spinner.View() + " Loading..."}, bodyRows)
+	}
+	if len(m.items) == 0 {
+		return fitHeight([]string{"  No items"}, bodyRows)
+	}
+
+	lines := m.renderListLines(contentWidth, bodyRows)
+	if m.loadingMore {
+		lines = append(lines, m.styles.dim.Render("  "+m.spinner.View()+" Loading next page..."))
+	}
+	return fitHeight(lines, bodyRows)
 }
 
 func (m DashboardModel) renderListPaneLines(width int, rows int) []string {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1702,13 +1702,13 @@ func (m DashboardModel) searchSuggestions(view ViewMode) []string {
 	}
 
 	for _, author := range m.searchMetadata.Authors {
-		if trimmed := strings.TrimSpace(author); trimmed != "" {
-			unique["author:"+trimmed] = struct{}{}
+		if suggestion := qualifierSuggestion("author", userDisplayValue(author)); suggestion != "" {
+			unique[suggestion] = struct{}{}
 		}
 	}
 	for _, assignee := range m.searchMetadata.Assignees {
-		if trimmed := strings.TrimSpace(assignee); trimmed != "" {
-			unique["assignee:"+trimmed] = struct{}{}
+		if suggestion := qualifierSuggestion("assignee", userDisplayValue(assignee)); suggestion != "" {
+			unique[suggestion] = struct{}{}
 		}
 	}
 	for _, label := range m.searchMetadata.Labels {
@@ -1743,6 +1743,13 @@ func qualifierSuggestion(key string, value string) string {
 		return fmt.Sprintf("%s:\"%s\"", key, replaced)
 	}
 	return key + ":" + trimmed
+}
+
+func userDisplayValue(user SearchUser) string {
+	if trimmed := strings.TrimSpace(user.Name); trimmed != "" {
+		return trimmed
+	}
+	return strings.TrimSpace(user.Username)
 }
 
 func (m *DashboardModel) resetSearchCompletionState() {

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -387,7 +387,7 @@ func TestDashboardSearchIncludesMetadataSuggestions(t *testing.T) {
 	suggestions := model.searchInput.AvailableSuggestions()
 	joined := strings.Join(suggestions, " ")
 
-	for _, expected := range []string{"author:", "author:alice", "assignee:bob", "label:backend", "milestone:\"Sprint 1\""} {
+	for _, expected := range []string{"author:", "author:alice", "assignee:bob", "label:backend", "milestone:Sprint 1"} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("expected suggestions to include %q, got %#v", expected, suggestions)
 		}
@@ -451,7 +451,7 @@ func TestDashboardSearchMetadataFromProviderAddsSuggestions(t *testing.T) {
 
 	suggestions := model.searchInput.AvailableSuggestions()
 	joined := strings.Join(suggestions, " ")
-	if !strings.Contains(joined, "author:\"Remote Alice\"") {
+	if !strings.Contains(joined, "author:Remote Alice") {
 		t.Fatalf("expected remote author suggestion, got %#v", suggestions)
 	}
 }

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -435,7 +435,7 @@ func TestDashboardSearchAutocompleteCompletesLastToken(t *testing.T) {
 func TestDashboardSearchMetadataFromProviderAddsSuggestions(t *testing.T) {
 	t.Parallel()
 
-	provider := &stubProvider{searchMetadata: SearchMetadata{Authors: []string{"remote-alice"}}}
+	provider := &stubProvider{searchMetadata: SearchMetadata{Authors: []SearchUser{{Name: "Remote Alice", Username: "4f8b8f90-aaaa-bbbb-cccc-1d2e3f4a5b6c"}}}}
 	m := NewDashboardModel(provider, DashboardContext{})
 	m.view = IssuesView
 	m.loading = false
@@ -451,7 +451,7 @@ func TestDashboardSearchMetadataFromProviderAddsSuggestions(t *testing.T) {
 
 	suggestions := model.searchInput.AvailableSuggestions()
 	joined := strings.Join(suggestions, " ")
-	if !strings.Contains(joined, "author:remote-alice") {
+	if !strings.Contains(joined, "author:\"Remote Alice\"") {
 		t.Fatalf("expected remote author suggestion, got %#v", suggestions)
 	}
 }

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -389,6 +389,44 @@ func TestDashboardSearchIncludesMetadataSuggestions(t *testing.T) {
 	}
 }
 
+func TestDashboardSearchAutocompleteCompletesCurrentToken(t *testing.T) {
+	t.Parallel()
+
+	m := NewDashboardModel(&stubProvider{}, DashboardContext{})
+	m.view = IssuesView
+	m.loading = false
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	model := updated.(DashboardModel)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("aut")})
+	model = updated.(DashboardModel)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(DashboardModel)
+	if model.searchInput.Value() != "author:" {
+		t.Fatalf("autocomplete value = %q want %q", model.searchInput.Value(), "author:")
+	}
+}
+
+func TestDashboardSearchAutocompleteCompletesLastToken(t *testing.T) {
+	t.Parallel()
+
+	m := NewDashboardModel(&stubProvider{}, DashboardContext{})
+	m.view = IssuesView
+	m.loading = false
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	model := updated.(DashboardModel)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("bug aut")})
+	model = updated.(DashboardModel)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(DashboardModel)
+	if model.searchInput.Value() != "bug author:" {
+		t.Fatalf("autocomplete value = %q want %q", model.searchInput.Value(), "bug author:")
+	}
+}
+
 func TestDashboardMergeRequestStateTabReloads(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/screen_issue.go
+++ b/internal/tui/screen_issue.go
@@ -1,5 +1,7 @@
 package tui
 
+import "fmt"
+
 import tea "github.com/charmbracelet/bubbletea"
 
 var issueKeyHints = []string{
@@ -64,14 +66,19 @@ func (m DashboardModel) handleIssueScreenKey(key string) (tea.Model, tea.Cmd, bo
 }
 
 func (m DashboardModel) renderIssueBody(width int) []string {
+	resultCount := fmt.Sprintf("results: %d", len(m.items))
+	if m.loading {
+		resultCount = "results: loading"
+	}
+	if m.loadingMore {
+		resultCount += " (+more)"
+	}
 	lines := []string{
 		" " + m.renderIssueTabs(max(20, width-8)),
 		" " + m.renderIssueSearch(max(20, width-8)),
-		m.styles.dim.Render(" sort: updated newest first"),
+		m.styles.dim.Render(" sort: updated newest first | " + resultCount),
+		m.styles.dim.Render(" keys: / search, tab complete, [ ] state, enter details, ? help"),
 		"",
-	}
-	for _, hint := range issueKeyHints {
-		lines = append(lines, m.styles.dim.Render(" "+hint))
 	}
 	return lines
 }

--- a/internal/tui/screen_issue.go
+++ b/internal/tui/screen_issue.go
@@ -5,6 +5,7 @@ import tea "github.com/charmbracelet/bubbletea"
 var issueKeyHints = []string{
 	"enter: open issue details",
 	"/: search",
+	"tab: autocomplete",
 	"[: prev state",
 	"]: next state",
 	"o/c/a: open/closed/all",
@@ -30,10 +31,7 @@ func (m DashboardModel) handleIssueScreenKey(key string) (tea.Model, tea.Cmd, bo
 			return m, tea.Batch(cmd, m.preloadMarkdownCmd()), true
 		}
 	case "/":
-		m.searchMode = true
-		m.searchInput.Focus()
-		m.searchInput.SetValue(m.issueSearch)
-		m.searchInput.CursorEnd()
+		m = m.openSearch(IssuesView)
 		return m, nil, true
 	case "[":
 		m.issueState = prevIssueState(m.issueState)

--- a/internal/tui/screen_issue.go
+++ b/internal/tui/screen_issue.go
@@ -32,7 +32,7 @@ func (m DashboardModel) handleIssueScreenKey(key string) (tea.Model, tea.Cmd, bo
 		}
 	case "/":
 		m = m.openSearch(IssuesView)
-		return m, nil, true
+		return m, m.loadSearchMetadataCmd(IssuesView), true
 	case "[":
 		m.issueState = prevIssueState(m.issueState)
 		m.selected = 0

--- a/internal/tui/screen_merge_request.go
+++ b/internal/tui/screen_merge_request.go
@@ -25,7 +25,7 @@ func (m DashboardModel) handleMergeRequestScreenKey(key string) (tea.Model, tea.
 		}
 	case "/":
 		m = m.openSearch(MergeRequestsView)
-		return m, nil, true
+		return m, m.loadSearchMetadataCmd(MergeRequestsView), true
 	case "[":
 		m.mergeRequestState = prevMergeRequestState(m.mergeRequestState)
 		m.selected = 0

--- a/internal/tui/screen_merge_request.go
+++ b/internal/tui/screen_merge_request.go
@@ -1,5 +1,7 @@
 package tui
 
+import "fmt"
+
 import tea "github.com/charmbracelet/bubbletea"
 
 var mergeRequestKeyHints = []string{
@@ -62,14 +64,19 @@ func (m DashboardModel) handleMergeRequestScreenKey(key string) (tea.Model, tea.
 }
 
 func (m DashboardModel) renderMergeRequestBody(width int) []string {
+	resultCount := fmt.Sprintf("results: %d", len(m.items))
+	if m.loading {
+		resultCount = "results: loading"
+	}
+	if m.loadingMore {
+		resultCount += " (+more)"
+	}
 	lines := []string{
 		" " + m.renderMergeRequestTabs(max(20, width-8)),
 		" " + m.renderMergeRequestSearch(max(20, width-8)),
-		m.styles.dim.Render(" sort: updated newest first"),
+		m.styles.dim.Render(" sort: updated newest first | " + resultCount),
+		m.styles.dim.Render(" keys: / search, tab complete, [ ] state, enter details, ? help"),
 		"",
-	}
-	for _, hint := range mergeRequestKeyHints {
-		lines = append(lines, m.styles.dim.Render(" "+hint))
 	}
 	return lines
 }

--- a/internal/tui/screen_merge_request.go
+++ b/internal/tui/screen_merge_request.go
@@ -4,6 +4,8 @@ import tea "github.com/charmbracelet/bubbletea"
 
 var mergeRequestKeyHints = []string{
 	"enter: open merge request details",
+	"/: search",
+	"tab: autocomplete",
 	"[: prev state",
 	"]: next state",
 	"o/m/c/a: open/merged/closed/all",
@@ -21,6 +23,9 @@ func (m DashboardModel) handleMergeRequestScreenKey(key string) (tea.Model, tea.
 			m.mergeRequestDetailScroll = 0
 			return m, nil, true
 		}
+	case "/":
+		m = m.openSearch(MergeRequestsView)
+		return m, nil, true
 	case "[":
 		m.mergeRequestState = prevMergeRequestState(m.mergeRequestState)
 		m.selected = 0
@@ -59,6 +64,7 @@ func (m DashboardModel) handleMergeRequestScreenKey(key string) (tea.Model, tea.
 func (m DashboardModel) renderMergeRequestBody(width int) []string {
 	lines := []string{
 		" " + m.renderMergeRequestTabs(max(20, width-8)),
+		" " + m.renderMergeRequestSearch(max(20, width-8)),
 		m.styles.dim.Render(" sort: updated newest first"),
 		"",
 	}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,6 +8,7 @@ type styles struct {
 	sidebarActive  lipgloss.Style
 	panel          lipgloss.Style
 	header         lipgloss.Style
+	issueID        lipgloss.Style
 	status         lipgloss.Style
 	helpPopup      lipgloss.Style
 	errorPopup     lipgloss.Style
@@ -39,6 +40,9 @@ func newStyles() styles {
 			Padding(0, 1),
 		header: lipgloss.NewStyle().
 			Foreground(accent).
+			Bold(true),
+		issueID: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("214")).
 			Bold(true),
 		status: lipgloss.NewStyle().
 			Foreground(lipgloss.Color("255")).

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -20,15 +20,18 @@ type ListItem struct {
 }
 
 type IssueDetails struct {
-	IID         int64
-	State       string
-	Author      string
-	Assignees   []string
-	Labels      []string
-	CreatedAt   string
-	UpdatedAt   string
-	URL         string
-	Description string
+	IID            int64
+	State          string
+	Author         string
+	AuthorLogin    string
+	Assignees      []string
+	AssigneeLogins []string
+	Labels         []string
+	Milestone      string
+	CreatedAt      string
+	UpdatedAt      string
+	URL            string
+	Description    string
 }
 
 type IssueComment struct {
@@ -79,6 +82,7 @@ const (
 
 type MergeRequestQuery struct {
 	State   MergeRequestState
+	Search  string
 	Page    int
 	PerPage int
 }
@@ -89,15 +93,20 @@ type MergeRequestResult struct {
 }
 
 type MergeRequestDetails struct {
-	IID          int64
-	State        string
-	Author       string
-	SourceBranch string
-	TargetBranch string
-	CreatedAt    string
-	UpdatedAt    string
-	URL          string
-	Description  string
+	IID            int64
+	State          string
+	Author         string
+	AuthorLogin    string
+	Assignees      []string
+	AssigneeLogins []string
+	Labels         []string
+	Milestone      string
+	SourceBranch   string
+	TargetBranch   string
+	CreatedAt      string
+	UpdatedAt      string
+	URL            string
+	Description    string
 }
 
 type DataProvider interface {

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -113,6 +113,14 @@ type DataProvider interface {
 	LoadIssues(ctx context.Context, query IssueQuery) (IssueResult, error)
 	LoadMergeRequests(ctx context.Context, query MergeRequestQuery) (MergeRequestResult, error)
 	LoadIssueDetailData(ctx context.Context, issueIID int64) (IssueDetailData, error)
+	LoadSearchMetadata(ctx context.Context, view ViewMode) (SearchMetadata, error)
+}
+
+type SearchMetadata struct {
+	Authors    []string
+	Assignees  []string
+	Labels     []string
+	Milestones []string
 }
 
 type DashboardContext struct {

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -117,10 +117,15 @@ type DataProvider interface {
 }
 
 type SearchMetadata struct {
-	Authors    []string
-	Assignees  []string
+	Authors    []SearchUser
+	Assignees  []SearchUser
 	Labels     []string
 	Milestones []string
+}
+
+type SearchUser struct {
+	Name     string
+	Username string
 }
 
 type DashboardContext struct {


### PR DESCRIPTION
## Summary
- add metadata-aware query parsing for issue and merge request search (`author:`, `assignee:`, `label:`, `milestone:`) while preserving free-text search
- add `/` search support for merge requests and autocomplete suggestions in search input for both issue and merge request views
- retrieve and render additional metadata (assignees, labels, milestone, logins) and add tests for parser behavior, provider mapping, and TUI search flows

## Testing
- just test

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced per-view search filtering for issues and merge requests (author, assignee, labels, milestone, and text)
  * Search suggestions, tab-autocomplete, and asynchronous search metadata (authors, assignees, labels, milestones) for smarter query entry
  * Enhanced issue and merge request detail views showing milestone, assignees, labels, and author identifiers
  * Quick-search activation ("/") from issue and MR screens

* **Tests**
  * Added unit and integration tests covering query parsing, provider filtering, metadata loading, and UI autocomplete behavior

* **Style**
  * Minor UI styling tweak for issue identifiers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->